### PR TITLE
chore: remove deprecated startup_script_timeout

### DIFF
--- a/aws-ecs-container/main.tf
+++ b/aws-ecs-container/main.tf
@@ -108,7 +108,6 @@ resource "coder_agent" "coder" {
   auth                   = "token"
   os                     = "linux"
   dir                    = "/home/coder"
-  startup_script_timeout = 180
   startup_script         = <<-EOT
     set -e
 


### PR DESCRIPTION
Creating a template from examples results in deprecation warnings

related to PR: https://github.com/coder/coder/pull/12104